### PR TITLE
SPEEEEEEEEED increase

### DIFF
--- a/src/main/java/space/earlygrey/simplegraphs/AlgorithmImplementations.java
+++ b/src/main/java/space/earlygrey/simplegraphs/AlgorithmImplementations.java
@@ -1,6 +1,8 @@
 package space.earlygrey.simplegraphs;
 
 
+import space.earlygrey.simplegraphs.utils.Heuristic;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -10,8 +12,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Set;
-
-import space.earlygrey.simplegraphs.utils.Heuristic;
 
 class AlgorithmImplementations<V> {
 
@@ -30,14 +30,29 @@ class AlgorithmImplementations<V> {
 
     AlgorithmImplementations(Graph<V> graph) {
         this.graph = graph;
-        priorityQueueWithEstimate = new PriorityQueue<>(Comparator.comparing(e -> e.distance + e.estimate));
-        priorityQueue = new PriorityQueue<>(Comparator.comparing(e -> e.distance));
+        priorityQueueWithEstimate = new PriorityQueue<>(estimateComparator);
+        priorityQueue = new PriorityQueue<>(distanceComparator);
         queue = new ArrayDeque<>();
     }
 
     //================================================================================
     // Util
     //================================================================================
+    
+    final Comparator<Node<V>> estimateComparator = new Comparator<Node<V>>() {
+
+        @Override
+        public int compare(Node<V> s, Node<V> e) {
+            return Float.floatToIntBits(s.distance + s.estimate - e.distance - e.estimate);
+        }
+    };
+    
+    final Comparator<Node<V>> distanceComparator = new Comparator<Node<V>>() {
+        @Override
+        public int compare(Node<V> o1, Node<V> o2) {
+            return Float.floatToIntBits(o1.distance - o2.distance);
+        }
+    };
 
     private void init() {
         runID++;
@@ -266,6 +281,20 @@ class AlgorithmImplementations<V> {
     // Minimum spanning trees
     //================================================================================
 
+    final Comparator<Connection<V>> weightComparator = new Comparator<Connection<V>>() {
+        @Override
+        public int compare(Connection<V> o1, Connection<V> o2) {
+            return Float.floatToIntBits(o1.weight - o2.weight);
+        }
+    };
+
+    final Comparator<Connection<V>> reverseWeightComparator = new Comparator<Connection<V>>() {
+        @Override
+        public int compare(Connection<V> o1, Connection<V> o2) {
+            return Float.floatToIntBits(o2.weight - o1.weight);
+        }
+    };
+    
     // adapted from https://www.baeldung.com/java-spanning-trees-kruskal
 
     Graph<V> kruskalsMinimumWeightSpanningTree(boolean minSpanningTree) {
@@ -278,9 +307,9 @@ class AlgorithmImplementations<V> {
         List<Connection<V>> edgeList = new ArrayList<>(graph.edgeMap.values());
 
         if (minSpanningTree) {
-           edgeList.sort(Comparator.comparing(e -> e.weight));
+           edgeList.sort(weightComparator);
         } else {
-           edgeList.sort(Collections.reverseOrder(Comparator.comparing(e -> e.weight)));
+           edgeList.sort(reverseWeightComparator);
         }
 
         int totalNodes = graph.size();


### PR DESCRIPTION
This removes some oddly-slow lambdas on hot paths; it instead uses specialized replacements that reduce calls to synchronization-related code.

Comparators.comparing() for float values results in some sorta-slow code, calling Float.floatToIntBits() and Float.intBitsToFloat() several times when it can be reduced to one call to Float.floatToIntBits() and some subtraction. This version won't really handle NaN well, but if your graph has NaN for a distance, it isn't a usable graph. It also treats -0.0f as less than 0.0f, but I doubt this is an issue. This version is about 15% faster, give or take 5%. I don't know how much effect Float.floatToIntBits() has by creating a synchronization checkpoint, but Comparator.comparing() does so several times per comparison.