### PR TITLE
Tiny fix for a major crash in NodeMap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,12 @@ if (JavaVersion.current().isJava8Compatible()) {
 repositories {
     mavenLocal()
     mavenCentral()
+    // when preparing a release to Maven Central, remove or comment this line:
     maven { url "https://jitpack.io" }
 }
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    // when preparing a release to Maven Central, remove or comment this line:
+    testImplementation 'com.github.SquidPony.SquidLib:squidlib-util:ae53eed80a'
 }

--- a/src/main/java/space/earlygrey/simplegraphs/NodeMap.java
+++ b/src/main/java/space/earlygrey/simplegraphs/NodeMap.java
@@ -60,6 +60,7 @@ class NodeMap<V> {
      * @return the `Node<V>` if v is not in the map, or null if it already is.
      */
     Node<V> put(V v) {
+        checkLength();
         int objectHash = v.hashCode(), hash = hash(objectHash);
         int i = getIndex(hash);
         Node<V> bucketHead = table[i];
@@ -80,7 +81,6 @@ class NodeMap<V> {
             currentNode = currentNode.nextInBucket;
         }
 
-        checkLength();
         currentNode = new Node<>(v, graph, objectHash);
         currentNode.mapHash = hash;
         previousNode.nextInBucket = currentNode;

--- a/src/test/java/space/earlygrey/simplegraphs/NodeMapCheck.java
+++ b/src/test/java/space/earlygrey/simplegraphs/NodeMapCheck.java
@@ -1,0 +1,84 @@
+package space.earlygrey.simplegraphs;
+
+import squidpony.squidgrid.Direction;
+import squidpony.squidgrid.mapping.DungeonGenerator;
+import squidpony.squidmath.Coord;
+import squidpony.squidmath.GreasedRegion;
+import squidpony.squidmath.StatefulRNG;
+
+public class NodeMapCheck {
+    public int DIMENSION = 28;
+    public DungeonGenerator dungeonGen = new DungeonGenerator(DIMENSION, DIMENSION, new StatefulRNG(0x1337BEEFDEAL));
+    public char[][] map;
+    public GreasedRegion floors;
+    public int floorCount;
+    public Coord[] floorArray;
+    public Coord[][] nearbyMap;
+    public StatefulRNG srng;
+
+    public DirectedGraph<Coord> simpleDirectedGraph;
+    public UndirectedGraph<Coord> simpleUndirectedGraph;
+
+    public space.earlygrey.simplegraphs.utils.Heuristic<Coord> simpleHeu;
+
+    public NodeMapCheck(){
+        Coord.expandPoolTo(DIMENSION, DIMENSION);
+        map = dungeonGen.generate();
+        floors = new GreasedRegion(map, '.');
+        floorCount = floors.size();
+        floorArray = floors.asCoords();
+        System.out.println("Floors: " + floorCount);
+        System.out.println("Percentage walkable: " + floorCount * 100.0 / (DIMENSION * DIMENSION) + "%");
+        nearbyMap = new Coord[DIMENSION][DIMENSION];
+        GreasedRegion tmp = new GreasedRegion(DIMENSION, DIMENSION);
+        srng = new StatefulRNG(0x1337BEEF1337CA77L);
+        Coord c;
+        for (int i = 1; i < DIMENSION - 1; i++) {
+            for (int j = 1; j < DIMENSION - 1; j++) {
+                if(map[i][j] == '#')
+                    continue;
+                c = tmp.empty().insert(i, j).flood(floors, 8).remove(i, j).singleRandom(srng);
+                nearbyMap[i][j] = c;
+            }
+        }
+
+        simpleDirectedGraph = new DirectedGraph<>(floors);
+
+        // should print true
+        System.out.println(floors.contains(Coord.get(22, 21)));
+        // should print true. Before, it did not due to get() not seeing the Coord in the NodeMap
+        System.out.println(simpleDirectedGraph.getVertices().contains(Coord.get(22, 21)));
+
+        simpleUndirectedGraph = new UndirectedGraph<>(floors);
+
+        simpleHeu = new space.earlygrey.simplegraphs.utils.Heuristic<Coord>() {
+            @Override
+            public float getEstimate(Coord currentNode, Coord targetNode) {
+                return Math.max(Math.abs(currentNode.x - targetNode.x), Math.abs(currentNode.y - targetNode.y));
+            }
+        };
+        Coord center;
+        Direction[] outer = Direction.CLOCKWISE;
+        Direction dir;
+        for (int i = floorCount - 1; i >= 0; i--) {
+            center = floorArray[i];
+            for (int j = 0; j < 8; j++) {
+                dir = outer[j];
+                if(floors.contains(center.x + dir.deltaX, center.y + dir.deltaY))
+                {
+                    simpleDirectedGraph.addEdge(center, center.translate(dir));
+                    if(!simpleUndirectedGraph.edgeExists(center, center.translate(dir)))
+                    {
+                        simpleUndirectedGraph.addEdge(center, center.translate(dir));
+                    }
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args){
+        NodeMapCheck nmc = new NodeMapCheck();
+        System.out.println(nmc.floorCount);
+        System.out.println(nmc.simpleDirectedGraph.getVertices().size());
+    }
+}


### PR DESCRIPTION
The `checkLength()` method was called after a node was hashed, but before it was added (at the old hash, in the new larger table). This would cause problems when the table resized during the insertion of a node that would have its hash change. Simply moving the `checkLength()` call to before the hash is calculated solves the bug.

I added a test that closely reproduces the situation I discovered the bug in; the bug should be fixed for any value you give to `DIMENSION`. You can move `checkLength()` back to where it was in `NodeMap.put()` to see the bug for yourself. You might want to remove the test-dependency on SquidLib if you are making a release to Maven Central, since it doesn't allow having JitPack as a repo. There's probably a good way to store one map and fill a graph with it that doesn't involve SquidLib, but this way was a lot easier for me.