### PR TITLE
Make Array.indexOf() use .equals().

### DIFF
--- a/src/main/java/space/earlygrey/simplegraphs/Array.java
+++ b/src/main/java/space/earlygrey/simplegraphs/Array.java
@@ -63,7 +63,7 @@ public class Array<T> extends AbstractCollection<T> {
 
     @Override
     public boolean remove(Object item) {
-        return remove(indexOf(item)) != null;
+        return item != null && remove(indexOf(item)) != null;
     }
 
 
@@ -86,10 +86,21 @@ public class Array<T> extends AbstractCollection<T> {
         }
     }
 
+    /**
+     * Gets the index of the first occurrence of {@code item} in this Array, or -1 if the argument is not present.
+     * Because {@code null} is used to indicate empty space, you cannot search for a "null item" with this -- it will
+     * throw an {@link IllegalArgumentException} if you do.
+     * @param item a non-null Object that could be in this Array (typically a T)
+     * @return the index of the first occurrence of {@code item} in this Array, or -1 if not present
+     */
     public int indexOf(Object item) {
-        for (int i = size-1; i >= 0; i--) {
-            if (item == items[i]) {
-                return i;
+        if(item == null) {
+            Errors.throwNullItemException();
+        } else {
+            for (int i = size - 1; i >= 0; i--) {
+                if (item.equals(items[i])) {
+                    return i;
+                }
             }
         }
         return -1;
@@ -142,7 +153,7 @@ public class Array<T> extends AbstractCollection<T> {
 
     @Override
     public boolean contains(Object o) {
-        return indexOf(o) >= 0;
+        return o != null && indexOf(o) >= 0;
     }
 
     @Override

--- a/src/main/java/space/earlygrey/simplegraphs/Errors.java
+++ b/src/main/java/space/earlygrey/simplegraphs/Errors.java
@@ -29,6 +29,10 @@ public class Errors {
         throw new IllegalArgumentException("Vertices cannot be null");
     }
 
+    public static void throwNullItemException() {
+        throw new IllegalArgumentException("No item can be null");
+    }
+
     public static void throwSameVertexException() {
         throw new IllegalArgumentException("Self loops are not allowed");
     }


### PR DESCRIPTION
This fixes #12 .
This also includes some additional null checks. They can be removed or kept; I have no particular need for them. I noticed that `remove()` used null to indicate nothing was found, which means null can't be stored in an Array meaningfully. That got me to a) check for null in `indexOf()` once, so each item doesn't have to be compared specially against a possibly null argument, and b) make `contains(null)` and `remove(null)` always return false and do nothing else. I didn't make setting or adding a null item throw an Exception; if you feel that's a good idea, I could add that, or you could. Thanks for taking a look!